### PR TITLE
Use select settings in test connection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,12 @@ internals.Connection.prototype.start = function (callback) {
         callback();
     };
 
-    var testConnection = new Memcache(this.settings.location, internals.testConnectionSettings);
+    var testConnectionSettings = Hoek.applyToDefaults(internals.testConnectionSettings, {
+      timeout: self.settings.timeout,
+      idle: self.settings.idle
+    });
+
+    var testConnection = new Memcache(this.settings.location, testConnectionSettings);
 
     testConnection.get('foobar', function (err) {
 


### PR DESCRIPTION
This changes the test connection settings to use the user defined timeout/idle settings if set, otherwise uses the defaults.
