### PR TITLE
change test connection timeout from 1 second to 5 seconds

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ internals.defaults = {
 };
 
 internals.testConnectionSettings = {
-  timeout: 1000,
+  timeout: 5000,
   idle: 1000,
   failures: 0,
   retries: 0,


### PR DESCRIPTION
Connecting to memcached at server startup would always timeout when the test connection timeout was only 1 second.  Once I changed it to 5 seconds, it worked every time.   
