### PR TITLE
Updated to latest version (2.0.0) of memcached module

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=0.10.30"
   },
   "dependencies": {
-    "memcached": "^0.2.8",
+    "memcached": "^2.0.0",
     "hoek": "2.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Memory leak had been identified in 0.2.8 per [this issue](https://github.com/3rd-Eden/node-memcached/issues/186).

```
catbox-memcached [master>] $ npm test

> catbox-memcached@1.0.3 test /Users/julian/dev/catbox-memcached
> make test-cov


  ..................................................

50 tests complete
Test duration: 85 ms
No global variable leaks detected
Coverage: 100.00%
```
