### PR TITLE
Fix(test-connection) test connection with location option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,7 @@ exports = module.exports = class Connection {
     async testConnection(settings) {
 
         const testSettings = {
+            location: settings.location,
             timeout: settings.timeout,
             idle: settings.idle,
             failures: 0,


### PR DESCRIPTION
## Context

Use memcached location parameters to test the connection.

## How to verify it

Set up a memcached server on other location than `127.0.0.1:11211` then the test connection should works.

```javascript
client = new Catbox.Client(require('catbox-memcached'), {
    location: "myhost:4242"
});
```