### PR TITLE
Support for node v18, ESM tests, connect on start

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -9,9 +9,23 @@ on:
 
 jobs:
   test:
-    uses: hapijs/.github/.github/workflows/ci-module.yml@master
-    with:
-      min-node-version: 14
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows, macos]
+        node: ["*", "16", "14"]
+    runs-on: ${{ matrix.os }}-latest
+    name: ${{ matrix.os }} node@${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: ${{ matrix.node == '*' }}
+      - name: install
+        run: npm install
+      - name: test
+        run: npm test
     services:
       memcached:
         image: memcached:alpine

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    uses: hapijs/.github/.github/workflows/ci-module.yml@master
     with:
       min-node-version: 14
     services:

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -12,10 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, windows, macos]
         node: ["*", "16", "14"]
-    runs-on: ${{ matrix.os }}-latest
-    name: ${{ matrix.os }} node@${{ matrix.node }}
+    runs-on: ubuntu-latest
+    name: ubuntu node@${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -5,28 +5,15 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['*', '14', '12']
-
+    uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    with:
+      min-node-version: 14
     services:
       memcached:
         image: memcached:alpine
         ports:
           - 11211:11211
-
-    runs-on: ubuntu-latest
-    name: ${{ matrix.os }} node@${{ matrix.node }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-      - name: install
-        run: npm install
-      - name: test
-        run: npm test

--- a/.labrc.js
+++ b/.labrc.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+    globals: [
+        // These come from build process of memcache-client
+        '__extends',
+        '__assign',
+        '__rest',
+        '__decorate',
+        '__param',
+        '__metadata',
+        '__awaiter',
+        '__generator',
+        '__exportStar',
+        '__createBinding',
+        '__values',
+        '__read',
+        '__spread',
+        '__spreadArrays',
+        '__spreadArray',
+        '__await',
+        '__asyncGenerator',
+        '__asyncDelegator',
+        '__asyncValues',
+        '__makeTemplateObject',
+        '__importStar',
+        '__importDefault',
+        '__classPrivateFieldGet',
+        '__classPrivateFieldSet'
+    ].join(',')
+};

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-### Options
+### `new CatboxMemcached.Engine(options)`
 
 - `host` - the Memcache server hostname. Defaults to `127.0.0.1`. **Cannot be used with `location`.**
 - `port` - the Memcache server port. Defaults to `11211`. **Cannot be used with `location`.**

--- a/API.md
+++ b/API.md
@@ -1,7 +1,6 @@
 
 ### `new CatboxMemcached.Engine(options)`
 
-- `host` - the Memcache server hostname. Defaults to `127.0.0.1`. **Cannot be used with `location`.**
-- `port` - the Memcache server port. Defaults to `11211`. **Cannot be used with `location`.**
-- `location` - the Memcache server hostname and port. Defaults to `127.0.0.1:11211`. Can be a String,
-  Array, or an Object as per [node-memcached location specification](https://github.com/3rd-Eden/node-memcached#server-locations).
+- `host` - the Memcache server hostname. Defaults to `127.0.0.1`. **Cannot be used with `server`.**
+- `port` - the Memcache server port. Defaults to `11211`. **Cannot be used with `server`.**
+- `server` - the Memcache server hostname and port. Defaults to `127.0.0.1:11211`. Can be a string or an object as per [memcache-client server specification](https://github.com/electrode-io/memcache/tree/3dd8e7cc3da3ec78ac45c4a69379e810cb25f6c7/packages/memcache-client#client-options).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
+Copyright (c) 2012-2022, Project contributors  
+Copyright (c) 2012-2020, Sideway Inc
 Copyright (c) 2012, Walmart.  
 All rights reserved.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,7 @@ exports.Engine = class CatboxMemcachedEngine {
 
     constructor(options = {}) {
 
+        Hoek.assert(!options.location, 'The "location" option has been replaced with "server", and it has a new format');
         Hoek.assert(!(options.server && (options.host || options.port)), 'Cannot specify both server and host/port when using memcached');
 
         this.settings = Hoek.applyToDefaults(internals.defaults, options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const Hoek = require('@hapi/hoek');
 const Boom = require('@hapi/boom');
+const Bourne = require('@hapi/bourne');
 const Memcache = require('memcached');
 
 
@@ -15,7 +16,7 @@ const internals = {
 };
 
 
-exports = module.exports = internals.Connection = class {
+exports.Engine = class CatboxMemcachedEngine {
 
     constructor(options = {}) {
 
@@ -41,7 +42,25 @@ exports = module.exports = internals.Connection = class {
         }
 
         this._client = new Memcache(this.settings.location, this.settings);
-        this.isConnected = true;
+
+        return new Promise((resolve, reject) => {
+
+            const server = this._client.servers[0];
+
+            this._client.version((err) => {
+
+                this._client.connections[server]?.removeListener('error', reject);
+
+                if (err) {
+                    return reject(err);
+                }
+
+                this.isConnected = true;
+                resolve();
+            });
+
+            this._client.connections[server]?.once('error', reject);
+        });
     }
 
     stop() {
@@ -102,7 +121,7 @@ exports = module.exports = internals.Connection = class {
                 }
 
                 try {
-                    var envelope = JSON.parse(result);
+                    var envelope = Bourne.parse(result);
                 }
                 catch (err) {
                     return reject(new Boom.Boom('Bad envelope content'));

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,16 @@
 'use strict';
 
 const Hoek = require('@hapi/hoek');
-const Boom = require('@hapi/boom');
 const Bourne = require('@hapi/bourne');
-const Memcache = require('memcached');
+const { MemcacheClient } = require('memcache-client');
 
 
 const internals = {
     defaults: {
         host: '127.0.0.1',
         port: 11211,
-        timeout: 1000,
-        idle: 1000
+        cmdTimeout: 1000,
+        Promise
     }
 };
 
@@ -20,12 +19,12 @@ exports.Engine = class CatboxMemcachedEngine {
 
     constructor(options = {}) {
 
-        Hoek.assert(!(options.location && (options.host || options.port)), 'Cannot specify both location and host/port when using memcached');
+        Hoek.assert(!(options.server && (options.host || options.port)), 'Cannot specify both server and host/port when using memcached');
 
         this.settings = Hoek.applyToDefaults(internals.defaults, options);
 
-        if (!this.settings.location) {
-            this.settings.location = `${this.settings.host}:${this.settings.port}`;
+        if (!this.settings.server) {
+            this.settings.server = `${this.settings.host}:${this.settings.port}`;
         }
 
         delete this.settings.port;
@@ -35,38 +34,22 @@ exports.Engine = class CatboxMemcachedEngine {
         this.isConnected = false;
     }
 
-    start() {
+    async start() {
 
         if (this._client) {
             return;
         }
 
-        this._client = new Memcache(this.settings.location, this.settings);
+        this._client = new MemcacheClient(this.settings);
 
-        return new Promise((resolve, reject) => {
-
-            const server = this._client.servers[0];
-
-            this._client.version((err) => {
-
-                this._client.connections[server]?.removeListener('error', reject);
-
-                if (err) {
-                    return reject(err);
-                }
-
-                this.isConnected = true;
-                resolve();
-            });
-
-            this._client.connections[server]?.once('error', reject);
-        });
+        await this._client.version();
+        this.isConnected = true;
     }
 
     stop() {
 
         if (this._client) {
-            this._client.end();
+            this._client.shutdown();
             this._client = null;
             this.isConnected = false;
         }
@@ -80,69 +63,57 @@ exports.Engine = class CatboxMemcachedEngine {
     validateSegmentName(name) {
 
         if (!name) {
-            throw new Boom.Boom('Empty string');
+            throw new Error('Empty string');
         }
 
         // https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L44-L49
 
         if (name.indexOf('\0') !== -1) {
-            throw new Boom.Boom('Includes null character');
+            throw new Error('Includes null character');
         }
 
         if (name.match(/\s/g)) {
-            throw new Boom.Boom('Includes spacing character(s)');
+            throw new Error('Includes spacing character(s)');
         }
 
         const { partition = '' } = this.settings;
 
         if (name.length + partition.length > 250) {
-            throw new Boom.Boom('Segment and partition name lengths exceeds 250 characters');
+            throw new Error('Segment and partition name lengths exceeds 250 characters');
         }
 
         return null;
     }
 
-    get(key) {
+    async get(key) {
 
-        if (!this.isConnected) {
-            return Promise.reject(new Boom.Boom('Connection is not ready'));
+        this.#assertConnected();
+
+        const result = await this._client.get(this.generateKey(key));
+
+        if (!result) {
+            return null;
         }
 
-        return new Promise((resolve, reject) => {
+        try {
+            var envelope = Bourne.parse(result.value);
+        }
+        catch (err) {
+            throw new Error('Bad envelope content');
+        }
 
-            this._client.get(this.generateKey(key), (err, result) => {
+        if (!envelope.item ||
+            !envelope.stored) {
 
-                if (err) {
-                    return reject(err);
-                }
+            throw new Error('Incorrect envelope structure');
+        }
 
-                if (!result) {
-                    return resolve(null);
-                }
-
-                try {
-                    var envelope = Bourne.parse(result);
-                }
-                catch (err) {
-                    return reject(new Boom.Boom('Bad envelope content'));
-                }
-
-                if (!envelope.item ||
-                    !envelope.stored) {
-
-                    return reject(new Boom.Boom('Incorrect envelope structure'));
-                }
-
-                resolve(envelope);
-            });
-        });
+        return envelope;
     }
 
-    set(key, value, ttl) {
+    async set(key, value, ttl) {
 
-        if (!this.isConnected) {
-            return Promise.reject(new Boom.Boom('Connection is not ready'));
-        }
+        this.#assertConnected();
 
         const envelope = {
             item: value,
@@ -151,46 +122,17 @@ exports.Engine = class CatboxMemcachedEngine {
         };
 
         const cacheKey = this.generateKey(key);
-
-        try {
-            var stringifiedEnvelope = JSON.stringify(envelope);
-        }
-        catch (err) {
-            return Promise.reject(new Boom.Boom(err.message));
-        }
-
+        const stringifiedEnvelope = JSON.stringify(envelope);
         const ttlSec = Math.max(1, Math.floor(ttl / 1000));
 
-        return new Promise((resolve, reject) => {
-
-            this._client.set(cacheKey, stringifiedEnvelope, ttlSec, (err) => {
-
-                if (err) {
-                    return reject(new Boom.Boom(err.message));
-                }
-
-                resolve();
-            });
-        });
+        await this._client.set(cacheKey, stringifiedEnvelope, { lifetime: ttlSec });
     }
 
-    drop(key) {
+    async drop(key) {
 
-        if (!this.isConnected) {
-            return Promise.reject(new Boom.Boom('Connection is not ready'));
-        }
+        this.#assertConnected();
 
-        return new Promise((resolve, reject) => {
-
-            this._client.del(this.generateKey(key), (err) => {
-
-                if (err) {
-                    return reject(new Boom.Boom(err.message));
-                }
-
-                resolve();
-            });
-        });
+        await this._client.delete(this.generateKey(key));
     }
 
     generateKey(key) {
@@ -204,5 +146,10 @@ exports.Engine = class CatboxMemcachedEngine {
         }
 
         return generatedKey;
+    }
+
+    #assertConnected() {
+
+        Hoek.assert(this.isConnected, 'Connection is not ready');
     }
 };

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/hoek": "9.x.x",
-    "memcached": "2.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "memcached": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/catbox": "11.x.x",
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/catbox": "^12.0.0",
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -r console -t 100 -a @hapi/code -L -m 15000",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "^10.0.0",
     "@hapi/hoek": "^10.0.0",
-    "memcached": "^2.0.0"
+    "memcache-client": "^1.0.1"
   },
   "devDependencies": {
     "@hapi/catbox": "^12.0.0",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let CatboxMemcached;
+
+    before(async () => {
+
+        CatboxMemcached = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(CatboxMemcached)).to.equal([
+            'Engine',
+            'default'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -338,6 +338,17 @@ describe('Client', () => {
             expect(fn).to.throw(Error);
         });
 
+        it('throws an error if given deprecated location', () => {
+
+            const fn = () => {
+
+                new CatboxMemcached({
+                    location: '127.0.0.1:11211'
+                });
+            };
+
+            expect(fn).to.throw(/The "location" option has been replaced with "server"/);
+        });
     });
 
     describe('start()', () => {


### PR DESCRIPTION
 - Support and test on node v18.
 - Update all deps for node v18.
 - Test ESM support.
 - Update export to `Engine` to be more ESM-friendly.
 - Ensure connectivity on `start()`.
 - Parse envelopes with bourne.
 - Replace underlying memcached package with memcache-client.  This means that the engine now takes different configuration!  Notably, `location` is replaced with `server`.
 - Errors thrown by the engine are now plain `Error`s rather than `Boom` errors, bringing this module in line with the other catbox engines.

If this looks good, this will go out as catbox-memcached v4.